### PR TITLE
Apply --no-group when copying to mounted shared areas

### DIFF
--- a/transfer-files
+++ b/transfer-files
@@ -31,8 +31,8 @@ SOURCE=$1
 DESTINATION=$2
 
 if [[ $DESTINATION == /shared* ]]; then
-    # can't apply linux permission to ACL permissions
-    OPTIONS="--no-perms"
+    # can't apply Linux permissions or group ownership to ACL-controlled shared areas
+    OPTIONS="--no-perms --no-group"
     SHARED=$DESTINATION
 else
     OPTIONS=""


### PR DESCRIPTION
Prevent rsync retries when copying to /shared by skipping group ownership

- Adds `--no-group` alongside `--no-perms` when destination is in /shared
- Prevents `rsync: chgrp failed` errors
- Avoids unnecessary retries despite successful file transfers